### PR TITLE
Add back lower keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.stl
 *.ai
 *.svg
+.DS_Store


### PR DESCRIPTION
oops, also switches back to original column offsets for rows further away than 4.

I'm still not ready to give up Let's Split / Planck arrow positioning on the bottom row, as well as the control cluster on the left, so I'm adding the two keys on the bottom row closest to the thumb cluster back in.

next steps are to translate the top key of the thumb cluster back down to have all 4. Then I'm gonna play with positioning on the thumb cluster. I'm not ready to give up 2u keys for space / shift just yet, but I might be able to fit a few more keys in than 2